### PR TITLE
Display as library in Mod Menu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,5 +21,10 @@
     "fabricloader": "*",
     "fabric-language-kotlin": "*",
     "minecraft": "*"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   }
 }


### PR DESCRIPTION
This would add the Mod Menu library badge to Aegis according to Mod Menu's documentation (https://github.com/TerraformersMC/ModMenu/wiki/API#Badges).
While only a minor change, it will help keep users mod lists cleaner and improve search filtering, especially because libraries are hidden by default.

Currently appears as:
<img src="https://user-images.githubusercontent.com/38622942/120123308-59ccdb00-c1ae-11eb-9df7-b43abced445a.jpg" width=500>

With the small change will appear as:
<img src="https://user-images.githubusercontent.com/38622942/120123310-5d606200-c1ae-11eb-981d-9bf6bc79b8b9.png" width=500>



